### PR TITLE
Only relay chat from channels that are supposed to relay them

### DIFF
--- a/src/main/java/eu/manuelgu/discordmc/listener/DiscordEventListener.java
+++ b/src/main/java/eu/manuelgu/discordmc/listener/DiscordEventListener.java
@@ -53,6 +53,10 @@ public class DiscordEventListener {
             }
         } else {
             if (relayChat) {
+                if (!DiscordMC.getDiscordToMinecraft().contains(event.getMessage().getChannel())) {
+                    return;
+                }
+                
                 String content = event.getMessage().getContent();
                 List<IUser> mentions = event.getMessage().getMentions();
                 List<IRole> roleMentions = event.getMessage().getRoleMentions();


### PR DESCRIPTION
Changes proposed in this pull request:
- Only send chat messages from discord channels that are supposed to be relayed

Raised [here](https://www.spigotmc.org/threads/discordmc.115935/page-14#post-1939652).
