### PR TITLE
Fixes for subscribing/unsubscribing, new chat format and filtering features

### DIFF
--- a/src/main/java/eu/manuelgu/discordmc/DiscordMC.java
+++ b/src/main/java/eu/manuelgu/discordmc/DiscordMC.java
@@ -1,12 +1,22 @@
 package eu.manuelgu.discordmc;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
 import eu.manuelgu.discordmc.listener.BukkitEventListener;
 import eu.manuelgu.discordmc.listener.ChatListener;
 import eu.manuelgu.discordmc.listener.DiscordEventListener;
 import eu.manuelgu.discordmc.update.Updater;
 import gnu.trove.set.hash.THashSet;
 import lombok.Getter;
-import org.bukkit.plugin.java.JavaPlugin;
 import sx.blah.discord.Discord4J;
 import sx.blah.discord.api.ClientBuilder;
 import sx.blah.discord.api.IDiscordClient;
@@ -17,13 +27,8 @@ import sx.blah.discord.modules.Configuration;
 import sx.blah.discord.util.DiscordException;
 import sx.blah.discord.util.RateLimitException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
 public class DiscordMC extends JavaPlugin {
-    public static DiscordMC instance;
+    private static DiscordMC instance;
 
     /**
      * Get the client instance
@@ -69,10 +74,28 @@ public class DiscordMC extends JavaPlugin {
         return instance;
     }
 
+    private static File userFormatsFile;
+
+    @Getter
+    private static YamlConfiguration userFormats;
+
     @Override
     public void onEnable() {
         instance = this;
         saveDefaultConfig();
+
+        userFormatsFile = new File(getDataFolder(), "userFormats.yml");
+        userFormats = new YamlConfiguration();
+
+        if (userFormatsFile.exists()) {
+            loadUserFormats();
+        } else {
+            try {
+                userFormatsFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
 
         // Disable all modules
         Configuration.LOAD_EXTERNAL_MODULES = false;
@@ -130,7 +153,6 @@ public class DiscordMC extends JavaPlugin {
         if (getConfig().getBoolean("settings.check_for_updates")) {
             Updater.sendUpdateMessage(this);
         }
-
     }
 
     @Override
@@ -168,4 +190,24 @@ public class DiscordMC extends JavaPlugin {
 
         getLogger().info("Successfully logged in with '" + event.getClient().getOurUser().getName() + "'");
     }
+
+    private static void loadUserFormats() {
+        try {
+            userFormats.load(userFormatsFile);
+        } catch (IOException | InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void saveUserFormats() {
+        try {
+            userFormatsFile.createNewFile();
+            userFormats.save(userFormatsFile);
+            loadUserFormats();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
 }

--- a/src/main/java/eu/manuelgu/discordmc/MessageAPI.java
+++ b/src/main/java/eu/manuelgu/discordmc/MessageAPI.java
@@ -29,6 +29,28 @@ public class MessageAPI {
      * @param message  the actual message which gets sent
      */
     public static void sendToMinecraft(IChannel origin, String username, String message) {
+        String formattedMessage = getFormattedMessage(origin, username);
+
+        DiscordMC.getSubscribedPlayers().forEach(uuid -> Bukkit.getPlayer(uuid).sendMessage(
+                EmojiParser.parseToAliases(formattedMessage
+                        .replaceAll("%message", ChatColor.stripColor(message)))));
+    }
+
+    /**
+     * Send a chat message to the Minecraft server console
+     *
+     * @param origin   {@link IChannel} the message came from
+     * @param username player who sent the message
+     * @param message  the actual message which gets sent
+     */
+    public static void sendToMinecraftConsole(IChannel origin, String username, String message) {
+        String formattedMessage = getFormattedMessage(origin, username);
+
+        Bukkit.getConsoleSender().sendMessage(
+                EmojiParser.parseToAliases(formattedMessage.replaceAll("%message", ChatColor.stripColor(message))));
+    }
+
+    private static String getFormattedMessage(final IChannel origin, final String username) {
         String format = (String) DiscordMC.getUserFormats().get(username, "-");
         String formattedMessage;
         if (!useIngameFormat || Objects.equals(format, "-")) {
@@ -39,11 +61,7 @@ public class MessageAPI {
         } else {
             formattedMessage = format.replace("%1$s", username).replace("%2$s", "%message");
         }
-
-
-        DiscordMC.getSubscribedPlayers().forEach(uuid -> Bukkit.getPlayer(uuid).sendMessage(
-                EmojiParser.parseToAliases(formattedMessage
-                        .replaceAll("%message", ChatColor.stripColor(message)))));
+        return formattedMessage;
     }
 
     /**

--- a/src/main/java/eu/manuelgu/discordmc/listener/BukkitEventListener.java
+++ b/src/main/java/eu/manuelgu/discordmc/listener/BukkitEventListener.java
@@ -22,9 +22,6 @@ public class BukkitEventListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (!getPlugin().getConfig().getBoolean("settings.send_game_login")) {
-            return;
-        }
         if (!hasChatPermission(event.getPlayer())) {
             return;
         } else {
@@ -33,6 +30,9 @@ public class BukkitEventListener implements Listener {
 
             // Add player as a permissive player
             DiscordMC.getSubscribedPlayers().add(event.getPlayer().getUniqueId());
+        }
+        if (!getPlugin().getConfig().getBoolean("settings.send_game_login")) {
+            return;
         }
         final String username = event.getPlayer().getName();
         final String formattedMessage = getPlugin().getConfig().getString("settings.templates.player_join_minecraft")
@@ -43,21 +43,20 @@ public class BukkitEventListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuit(PlayerQuitEvent event) {
-        if (!getPlugin().getConfig().getBoolean("settings.send_game_logout")) {
-            return;
-        }
+        // Remove player as a permissive player
+        DiscordMC.getSubscribedPlayers().remove(event.getPlayer().getUniqueId());
         if (!DiscordMC.getCachedHasChatPermission().contains(event.getPlayer().getUniqueId())) {
             return;
         }
         DiscordMC.getCachedHasChatPermission().remove(event.getPlayer().getUniqueId());
+        if (!getPlugin().getConfig().getBoolean("settings.send_game_logout")) {
+            return;
+        }
         final String username = event.getPlayer().getName();
         final String formattedMessage = getPlugin().getConfig().getString("settings.templates.player_leave_minecraft")
                 .replaceAll("%user", username);
 
         MessageAPI.sendToDiscord(formattedMessage);
-
-        // Remove player as a permissive player
-        DiscordMC.getSubscribedPlayers().remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/eu/manuelgu/discordmc/listener/DiscordEventListener.java
+++ b/src/main/java/eu/manuelgu/discordmc/listener/DiscordEventListener.java
@@ -19,17 +19,19 @@ import sx.blah.discord.handle.obj.Status;
 
 public class DiscordEventListener {
     private final DiscordMC plugin;
-    private boolean relayChat;
-    private boolean commands;
-    private boolean useNickname;
-    private String commandPrefix;
+    private final boolean relayChat;
+    private final boolean sendToConsole;
+    private final boolean commands;
+    private final boolean useNickname;
+    private final String commandPrefix;
 
     public DiscordEventListener(DiscordMC plugin) {
         this.plugin = plugin;
-        relayChat = plugin.getConfig().getBoolean("settings.send_discord_chat", true);
-        commands = plugin.getConfig().getBoolean("settings.discord_commands.enabled", true);
-        useNickname = plugin.getConfig().getBoolean("settings.use_nicknames", true);
-        commandPrefix = plugin.getConfig().getString("settings.discord_commands.command_prefix", "?");
+        this.relayChat = plugin.getConfig().getBoolean("settings.send_discord_chat", true);
+        this.commands = plugin.getConfig().getBoolean("settings.discord_commands.enabled", true);
+        this.useNickname = plugin.getConfig().getBoolean("settings.use_nicknames", true);
+        this.commandPrefix = plugin.getConfig().getString("settings.discord_commands.command_prefix", "?");
+        this.sendToConsole = plugin.getConfig().getBoolean("settings.send_game_chat_also_to_console", true);
     }
 
     @EventSubscriber
@@ -86,6 +88,10 @@ public class DiscordEventListener {
                     nickname = event.getMessage().getAuthor().getName();
                 }
                 MessageAPI.sendToMinecraft(event.getMessage().getChannel(), nickname, finalContent);
+
+                if (sendToConsole) {
+                    MessageAPI.sendToMinecraftConsole(event.getMessage().getChannel(), nickname, finalContent);
+                }
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,9 @@ settings:
   send_death_message: true
   use_nicknames: false
   use_mentions: true
+  use_ingame_format: true
   check_for_updates: true
+  admin_chat_prefix: "§cAdminChat>"
   templates:
     chat_message_discord: '**%user**: %message'
     player_join_minecraft: '%user joined the game'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ settings:
   send_game_login: true
   send_game_logout: true
   send_game_chat: true
+  send_game_chat_also_to_console: true
   send_discord_chat: true
   send_death_message: true
   use_nicknames: false


### PR DESCRIPTION
- Fixes for subscribing/unsubscribing on join/quit
- Add possibility to use in-game chat format for messages sent to and from discord (players will see exactly the same chat format for messages send from discord and from game)
  - On the first message sent in-game, the users format is saved and later used as format for messages sent from discord by user with the same nickname.
  - Messages sent in-game are formated in the same way in discord chat (minus colors).
- Add posibility to specify adnim chat channel prefix, so admin messages are not sent to discord