### PR TITLE
Change AsyncPlayerChatEvent to add integration

### DIFF
--- a/src/main/java/eu/manuelgu/discordmc/listener/ChatListener.java
+++ b/src/main/java/eu/manuelgu/discordmc/listener/ChatListener.java
@@ -27,7 +27,7 @@ public class ChatListener implements Listener {
         this.adminChatPrefix = getPlugin().getConfig().getString("settings.admin_chat_prefix", "§cAdminChat>");
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
         if (event.isCancelled()) {
             return;


### PR DESCRIPTION
So i run a server where i have admin chat, staff chat and normal chat. And obviously i only want normal chat to be sent to the discord server but because the staff chat plugin (StaffPlus) uses priority "highest" and yours does too all messages in my staff chat get sent to discord. Using priority monitor makes sense too because your listener will never cancel the event or change anything in the event outcome it will just relay the message. just by changing that you would have added integration to the plugin StaffPlus and probably many others. i already changed that and compiled in my server but i thought i'd let you know.